### PR TITLE
Add consent feature with controller, service, and repository

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/controller/ConsentController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/controller/ConsentController.java
@@ -1,0 +1,26 @@
+package com.teambiund.bander.auth_server.controller;
+
+
+import com.teambiund.bander.auth_server.dto.request.ConsentRequest;
+import com.teambiund.bander.auth_server.exceptions.CustomException;
+import com.teambiund.bander.auth_server.service.signup.ConsentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/auth/consent")
+@RequiredArgsConstructor
+public class ConsentController {
+    private final ConsentService consentService;
+
+    @PutMapping
+    public ResponseEntity<Boolean> consent(String userId, List<ConsentRequest> requests) throws CustomException {
+        consentService.changeConsent(userId, requests);
+        return ResponseEntity.ok(true);
+    }
+}


### PR DESCRIPTION
---

### Summary

This pull request introduces a comprehensive implementation of the consent functionality.

### Key Changes

1. **Consent Controller**: Added a new controller to manage consent changes with corresponding PUT endpoints.
2. **Consent Service**: Implemented consent change and validation logic, including a service for signup integration.
3. **Validation Logic**: Included methods for verifying required consents.
4. **Entities and Repositories**:
   - Added `Consent` entity with proper mappings.
   - Added JPA repository for the `Consent` entity.
5. **Database Schema**:
   - Added `Consent` table creation SQL.
   - Updated other relevant schemas to support `Consent` features.
6. **Error Codes and DTOs**:
   - Defined required DTOs for consent handling.
   - Added error codes for consent-specific errors.
7. **Testing**:
   - Unit and integration tests for consent validation and processing.
   - Additional test cases for signup and user consent workflows.
8. **Refactoring**:
   - Removed redundant logic and improved code readability in related classes.

### Notes

- **Backward Compatibility**: These changes do not affect the existing features and workflows.
- **Database Update**: Includes schema changes. A migration is required to apply these updates.
- **Documentation Update**: Added functionality will require corresponding API documentation updates. 

--- 

### Checklist

- [ ] API documentation is updated for the new endpoints.
- [ ] Database migration scripts are tested and applied. 
- [ ] Dependencies and configurations are reviewed for the new changes.