### PR TITLE
[FIX] 네이밍 컨벤션 위반 및 오타 수정

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/aop/statistics/ApiRequestCountAspect.java
+++ b/src/main/java/com/teambiund/bander/auth_server/aop/statistics/ApiRequestCountAspect.java
@@ -1,4 +1,4 @@
-package com.teambiund.bander.auth_server.aop.statictics;
+package com.teambiund.bander.auth_server.aop.statistics;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.concurrent.CompletableFuture;

--- a/src/main/java/com/teambiund/bander/auth_server/aop/statistics/ApiRequestStat.java
+++ b/src/main/java/com/teambiund/bander/auth_server/aop/statistics/ApiRequestStat.java
@@ -1,4 +1,4 @@
-package com.teambiund.bander.auth_server.aop.statictics;
+package com.teambiund.bander.auth_server.aop.statistics;
 
 
 import com.teambiund.bander.auth_server.util.generator.key.KeyProvider;

--- a/src/main/java/com/teambiund/bander/auth_server/controller/enums/ConsentsController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/controller/enums/ConsentsController.java
@@ -1,9 +1,9 @@
 package com.teambiund.bander.auth_server.controller.enums;
 
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.consentMaps;
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.consentsAllMaps;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.consentMaps;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.consentsAllMaps;
 
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/teambiund/bander/auth_server/controller/healthCheckController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/controller/healthCheckController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/health")
 @Slf4j
-public class healthCheckController {
+public class HealthCheckController {
 
   @GetMapping
   public String healthCheck() {

--- a/src/main/java/com/teambiund/bander/auth_server/entity/consentsname/ConsentsTable.java
+++ b/src/main/java/com/teambiund/bander/auth_server/entity/consentsname/ConsentsTable.java
@@ -1,4 +1,4 @@
-package com.teambiund.bander.auth_server.entity.consents_name;
+package com.teambiund.bander.auth_server.entity.consentsname;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/teambiund/bander/auth_server/repository/ConsentTableRepository.java
+++ b/src/main/java/com/teambiund/bander/auth_server/repository/ConsentTableRepository.java
@@ -1,6 +1,6 @@
 package com.teambiund.bander.auth_server.repository;
 
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/teambiund/bander/auth_server/service/consent/impl/ConsentManagementServiceImpl.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/consent/impl/ConsentManagementServiceImpl.java
@@ -1,11 +1,11 @@
 package com.teambiund.bander.auth_server.service.consent.impl;
 
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.consentsAllMaps;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.consentsAllMaps;
 
 import com.teambiund.bander.auth_server.dto.request.ConsentRequest;
 import com.teambiund.bander.auth_server.entity.Auth;
 import com.teambiund.bander.auth_server.entity.Consent;
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import com.teambiund.bander.auth_server.exceptions.CustomException;
 import com.teambiund.bander.auth_server.exceptions.ErrorCode.ErrorCode;
 import com.teambiund.bander.auth_server.repository.AuthRepository;

--- a/src/main/java/com/teambiund/bander/auth_server/util/data/ConsentTableInit.java
+++ b/src/main/java/com/teambiund/bander/auth_server/util/data/ConsentTableInit.java
@@ -1,7 +1,7 @@
 package com.teambiund.bander.auth_server.util.data;
 
 
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import com.teambiund.bander.auth_server.repository.ConsentTableRepository;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ConsentTable_init {
+public class ConsentTableInit {
     public static final HashMap<String, ConsentsTable> consentMaps = new HashMap<>();
     public static final List<ConsentsTable> requiredConsents = new ArrayList<>();
     public static final HashMap<String, ConsentsTable> consentsAllMaps = new HashMap<>();

--- a/src/main/java/com/teambiund/bander/auth_server/validation/RequiredConsentsValidator.java
+++ b/src/main/java/com/teambiund/bander/auth_server/validation/RequiredConsentsValidator.java
@@ -1,10 +1,10 @@
 package com.teambiund.bander.auth_server.validation;
 
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.requiredConsents;
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.consentsAllMaps;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.requiredConsents;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.consentsAllMaps;
 
 import com.teambiund.bander.auth_server.dto.request.ConsentRequest;
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.List;

--- a/src/test/java/com/teambiund/bander/auth_server/service/consent/ConsentManagementServiceImplTest.java
+++ b/src/test/java/com/teambiund/bander/auth_server/service/consent/ConsentManagementServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.teambiund.bander.auth_server.service.consent;
 
-import static com.teambiund.bander.auth_server.util.data.ConsentTable_init.consentsAllMaps;
+import static com.teambiund.bander.auth_server.util.data.ConsentTableInit.consentsAllMaps;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.*;
 import com.teambiund.bander.auth_server.dto.request.ConsentRequest;
 import com.teambiund.bander.auth_server.entity.Auth;
 import com.teambiund.bander.auth_server.entity.Consent;
-import com.teambiund.bander.auth_server.entity.consents_name.ConsentsTable;
+import com.teambiund.bander.auth_server.entity.consentsname.ConsentsTable;
 import com.teambiund.bander.auth_server.enums.Status;
 import com.teambiund.bander.auth_server.exceptions.CustomException;
 import com.teambiund.bander.auth_server.exceptions.ErrorCode.ErrorCode;


### PR DESCRIPTION
## 목적

코드베이스 전반의 네이밍 컨벤션 위반 및 철자 오류를 수정하여 코드 품질과 검색성을 향상시켰습니다.

## 변경 요약

### 1. 클래스명 Java 네이밍 컨벤션 준수

#### healthCheckController → HealthCheckController
- **문제**: Java 클래스명은 대문자로 시작해야 함
- **위치**: `controller/HealthCheckController.java`
- **영향**: 1개 파일

#### ConsentTable_init → ConsentTableInit
- **문제**: 클래스명에 언더스코어 사용 금지
- **위치**: `util/data/ConsentTableInit.java`
- **영향**: 6개 파일 (import 구문 수정)
  - ConsentsController.java
  - ConsentManagementServiceImpl.java
  - RequiredConsentsValidator.java
  - ConsentManagementServiceImplTest.java

### 2. 패키지명 수정

#### statictics → statistics (오타 수정)
- **문제**: 올바른 철자는 "statistics"
- **위치**: `aop/statistics/`
- **영향**: 2개 파일
  - ApiRequestCountAspect.java
  - ApiRequestStat.java

#### consents_name → consentsname (언더스코어 제거)
- **문제**: Java 패키지명은 소문자만 사용, 언더스코어 금지
- **위치**: `entity/consentsname/`
- **영향**: 7개 파일
  - ConsentsTable.java (패키지 선언)
  - ConsentTableRepository.java
  - ConsentTableInit.java
  - ConsentsController.java
  - ConsentManagementServiceImpl.java
  - RequiredConsentsValidator.java
  - ConsentManagementServiceImplTest.java

## 수정된 네이밍 오류 상세

| # | 구분 | Before | After | 심각도 | 이유 |
|---|------|--------|-------|--------|------|
| 1 | 클래스명 | healthCheckController | HealthCheckController | 높음 | Java Convention 위반 |
| 2 | 클래스명 | ConsentTable_init | ConsentTableInit | 높음 | 언더스코어 사용 금지 |
| 3 | 패키지명 | statictics | statistics | 높음 | 철자 오류 |
| 4 | 패키지명 | consents_name | consentsname | 중간 | 언더스코어 사용 금지 |

## 변경 전후 비교

### Before:
```java
// 잘못된 클래스명
public class healthCheckController { }
public class ConsentTable_init { }

// 잘못된 패키지명
package com.teambiund.bander.auth_server.aop.statictics;
package com.teambiund.bander.auth_server.entity.consents_name;
```

### After:
```java
// 올바른 클래스명
public class HealthCheckController { }
public class ConsentTableInit { }

// 올바른 패키지명
package com.teambiund.bander.auth_server.aop.statistics;
package com.teambiund.bander.auth_server.entity.consentsname;
```

## 코드 개선 효과

### 1. 검색성 향상
- **Before**: "ConsentTable init"으로 검색 시 찾기 어려움
- **After**: "ConsentTableInit"으로 IDE 자동완성 및 검색 용이

### 2. 코드 가독성 향상
- Java 네이밍 컨벤션 준수로 일관된 코드 스타일 유지
- 새로운 개발자가 코드를 이해하기 쉬워짐

### 3. IDE 지원 개선
- 클래스명이 대문자로 시작하여 IntelliJ, VSCode 등의 자동완성 기능 향상
- 패키지명에 언더스코어가 없어 리팩토링 도구가 더 잘 작동

### 4. 오타 제거로 오해 방지
- "statictics" → "statistics" 수정으로 코드 검토 시 혼란 제거

## 수용 기준 검증

- [x] 모든 클래스명이 대문자로 시작
- [x] 클래스명과 패키지명에 언더스코어 없음
- [x] 철자 오류 수정
- [x] 모든 import 구문 업데이트
- [x] 테스트 전체 통과

## 테스트

### 전체 테스트 결과
```bash
./gradlew test --rerun-tasks
BUILD SUCCESSFUL in 10s
5 actionable tasks: 5 executed
```

### 수동 검증 방법

```bash
# 1. 네이밍 컨벤션 위반 검색 (결과 없어야 함)
find src -name "*_*.java" | grep -v "test"  # 언더스코어 포함 파일명
grep -r "class [a-z]" src/main --include="*.java"  # 소문자 시작 클래스명

# 2. 패키지 구조 확인
tree src/main/java/com/teambiund/bander/auth_server/aop/
tree src/main/java/com/teambiund/bander/auth_server/entity/

# 3. 빌드 성공 확인
./gradlew build
```

## 브레이킹/마이그레이션

**Breaking Change: 없음**

이 변경은 내부 구조 변경만 포함하며, 다음에는 영향을 주지 않습니다:
- API 엔드포인트
- 데이터베이스 스키마
- 외부 인터페이스
- 런타임 동작

단, 다른 브랜치에서 작업 중인 경우:
1. 이 PR 머지 후 rebase 필요
2. import 구문 자동 업데이트 (IDE에서 자동 처리)

## 영향 범위

- **변경된 파일**: 10개
- **파일명/패키지 이동**: 4개
- **import 수정**: 9개
- **코드 로직 변경**: 없음 (네이밍만 수정)

## 참조

- Closes #39

## 체크리스트

- [x] 빌드 성공
- [x] 모든 테스트 통과
- [x] Java 네이밍 컨벤션 준수
- [x] 철자 오류 수정
- [x] import 구문 업데이트