### PR TITLE
[FEATURE] 카카오 및 애플 소셜 로그인 구현

### DIFF
--- a/docs/SOCIAL_LOGIN_SETUP.md
+++ b/docs/SOCIAL_LOGIN_SETUP.md
@@ -1,0 +1,264 @@
+# 소셜 로그인 설정 가이드
+
+## 개요
+
+카카오와 애플 소셜 로그인을 지원합니다. 각 플랫폼에서 발급받은 Access Token 또는 Identity Token을 사용하여 로그인합니다.
+
+## 아키텍처
+
+### 로그인 흐름
+
+1. 클라이언트가 카카오/애플 SDK를 통해 Access Token 또는 Identity Token 획득
+2. 클라이언트가 Auth Server에 Token과 함께 로그인 요청
+3. Auth Server가 해당 플랫폼 API로 사용자 정보 조회
+4. 이메일 기반으로 기존 사용자 확인
+   - 신규 사용자: 회원가입 처리 후 로그인
+   - 기존 사용자: 로그인 처리
+5. JWT Access Token 및 Refresh Token 발급
+
+### 구조
+
+```
+Client
+  ↓ (카카오/애플 Access Token)
+SocialLoginController
+  ↓
+SocialLoginService
+  ├─ KakaoOAuthClient (카카오 사용자 정보 조회)
+  ├─ AppleOAuthClient (애플 사용자 정보 조회)
+  ├─ SignupService (신규 사용자 회원가입)
+  └─ LoginService (로그인 처리 및 토큰 발급)
+```
+
+## 카카오 로그인 설정
+
+### 1. 카카오 개발자 콘솔 설정
+
+1. Kakao Developers 접속
+   - https://developers.kakao.com/
+
+2. 애플리케이션 추가
+   - 내 애플리케이션 → 애플리케이션 추가하기
+   - 앱 이름, 사업자명 입력
+
+3. 플랫폼 설정
+   - 플랫폼 → Web 플랫폼 등록
+   - 사이트 도메인 입력 (예: https://yourdomain.com)
+
+4. 카카오 로그인 활성화
+   - 제품 설정 → 카카오 로그인
+   - 카카오 로그인 활성화 ON
+   - Redirect URI 등록 (예: https://yourdomain.com/oauth/kakao/callback)
+
+5. 동의항목 설정
+   - 제품 설정 → 카카오 로그인 → 동의항목
+   - 이메일 (필수 동의)
+   - 프로필 정보 (선택 동의)
+
+6. REST API 키 확인
+   - 앱 설정 → 앱 키
+   - REST API 키 복사 (클라이언트에서 사용)
+
+### 2. 환경 변수 설정
+
+```bash
+# application-dev.yaml 또는 application-prod.yaml
+oauth:
+  kakao:
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+```
+
+### 3. API 호출 예시
+
+```bash
+POST /api/auth/social/kakao
+Content-Type: application/json
+
+{
+  "accessToken": "{카카오 Access Token}",
+  "deviceId": "optional-device-id"
+}
+```
+
+## 애플 로그인 설정
+
+### 1. Apple Developer 설정
+
+1. Apple Developer 접속
+   - https://developer.apple.com/account/
+
+2. Certificates, Identifiers & Profiles 접근
+   - Identifiers → App IDs 선택
+   - 새 App ID 등록 또는 기존 App ID 선택
+
+3. Sign in with Apple 활성화
+   - App ID 편집
+   - Capabilities → Sign in with Apple 체크
+
+4. Services ID 생성
+   - Identifiers → Services IDs
+   - 새 Services ID 등록
+   - Sign in with Apple 활성화
+   - Domains and Subdomains 입력
+   - Return URLs 입력 (예: https://yourdomain.com/oauth/apple/callback)
+
+5. Key 생성
+   - Keys → 새 Key 등록
+   - Sign in with Apple 선택
+   - Configure 클릭하여 Primary App ID 선택
+   - Key 다운로드 (.p8 파일)
+   - Key ID 확인
+
+### 2. 환경 변수 설정
+
+```bash
+# application-dev.yaml 또는 application-prod.yaml
+oauth:
+  apple:
+    issuer: https://appleid.apple.com
+```
+
+### 3. API 호출 예시
+
+```bash
+POST /api/auth/social/apple
+Content-Type: application/json
+
+{
+  "accessToken": "{애플 Identity Token}",
+  "deviceId": "optional-device-id"
+}
+```
+
+## API 명세
+
+### 카카오 로그인
+
+```
+POST /api/auth/social/kakao
+```
+
+#### Request Body
+```json
+{
+  "accessToken": "string (required) - 카카오 Access Token",
+  "deviceId": "string (optional) - 클라이언트 Device ID"
+}
+```
+
+#### Response
+```json
+{
+  "accessToken": "string - JWT Access Token",
+  "refreshToken": "string - JWT Refresh Token",
+  "deviceId": "string - Device ID (요청에 포함되지 않은 경우 자동 생성)"
+}
+```
+
+#### Error Response
+- `400 SOCIAL_LOGIN_FAILED`: 소셜 로그인 실패
+- `400 EMAIL_ALREADY_EXISTS`: 이미 다른 방식으로 가입된 이메일
+- `401 UNAUTHORIZED`: 유효하지 않은 Access Token
+
+### 애플 로그인
+
+```
+POST /api/auth/social/apple
+```
+
+#### Request Body
+```json
+{
+  "accessToken": "string (required) - 애플 Identity Token",
+  "deviceId": "string (optional) - 클라이언트 Device ID"
+}
+```
+
+#### Response
+```json
+{
+  "accessToken": "string - JWT Access Token",
+  "refreshToken": "string - JWT Refresh Token",
+  "deviceId": "string - Device ID (요청에 포함되지 않은 경우 자동 생성)"
+}
+```
+
+#### Error Response
+- `400 SOCIAL_LOGIN_FAILED`: 소셜 로그인 실패
+- `400 EMAIL_ALREADY_EXISTS`: 이미 다른 방식으로 가입된 이메일
+- `401 UNAUTHORIZED`: 유효하지 않은 Identity Token
+
+## 주의사항
+
+### 보안
+
+1. Access Token은 HTTPS를 통해서만 전송해야 합니다
+2. Identity Token의 검증은 서버에서 수행됩니다
+3. 클라이언트에서 받은 Token을 재검증하지 않고 신뢰하지 마세요
+
+### Provider 정책
+
+1. 동일한 이메일로 다른 Provider로 가입할 수 없습니다
+   - 예: kakao@email.com으로 카카오 가입 후, 동일 이메일로 애플 로그인 불가
+   - `EMAIL_ALREADY_EXISTS` 에러 반환
+
+2. 신규 사용자는 자동으로 회원가입 처리됩니다
+   - Provider 정보와 이메일만 저장됩니다
+   - 비밀번호는 저장되지 않습니다
+   - 프로필 생성 이벤트가 발행됩니다
+
+### 테스트
+
+1. 개발 환경에서 테스트 시 실제 카카오/애플 Token이 필요합니다
+2. 단위 테스트에서는 Mock을 사용합니다
+3. 통합 테스트 시 환경 변수 설정을 확인하세요
+
+## 트러블슈팅
+
+### 카카오 로그인 실패
+
+**증상**: `SOCIAL_LOGIN_FAILED` 에러 발생
+
+**원인 및 해결**:
+1. Access Token 만료
+   - 카카오 SDK에서 새로운 Token 재발급
+
+2. 카카오 API 호출 실패
+   - 네트워크 연결 확인
+   - 카카오 서버 상태 확인 (https://status.kakao.com/)
+
+3. 이메일 정보 없음
+   - 카카오 개발자 콘솔에서 이메일 동의항목 필수로 설정
+   - 사용자에게 이메일 제공 동의 요청
+
+### 애플 로그인 실패
+
+**증상**: `SOCIAL_LOGIN_FAILED` 에러 발생
+
+**원인 및 해결**:
+1. Identity Token 형식 오류
+   - JWT 형식 확인 (header.payload.signature)
+   - Base64 URL 인코딩 확인
+
+2. Identity Token 파싱 실패
+   - Token 만료 여부 확인
+   - 애플 SDK 설정 확인
+
+3. 이메일 또는 sub 정보 없음
+   - 애플 Developer 콘솔에서 Sign in with Apple 설정 확인
+   - 클라이언트 요청 시 scope에 email 포함 확인
+
+### Provider 불일치 에러
+
+**증상**: `EMAIL_ALREADY_EXISTS` 에러 발생
+
+**해결**:
+1. 사용자에게 기존 가입 방식 안내
+2. 기존 계정으로 로그인 유도
+3. 필요 시 계정 연동 기능 구현 고려
+
+## 참고 문서
+
+- 카카오 로그인 API: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
+- Sign in with Apple: https://developer.apple.com/documentation/sign_in_with_apple
+- JWT 디코딩: https://jwt.io/

--- a/src/main/java/com/teambiund/bander/auth_server/client/oauth/AppleOAuthClient.java
+++ b/src/main/java/com/teambiund/bander/auth_server/client/oauth/AppleOAuthClient.java
@@ -1,0 +1,67 @@
+package com.teambiund.bander.auth_server.client.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teambiund.bander.auth_server.dto.response.AppleUserInfo;
+import com.teambiund.bander.auth_server.exceptions.CustomException;
+import com.teambiund.bander.auth_server.exceptions.ErrorCode.ErrorCode;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthClient {
+
+  private final ObjectMapper objectMapper;
+
+  public AppleUserInfo getUserInfo(String identityToken) {
+    try {
+      String[] tokenParts = identityToken.split("\\.");
+      if (tokenParts.length != 3) {
+        log.error("Apple Identity Token 형식 오류");
+        throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+      }
+
+      String payload = tokenParts[1];
+      String decodedPayload =
+          new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
+
+      Map<String, Object> claims = objectMapper.readValue(decodedPayload, Map.class);
+
+      String email = (String) claims.get("email");
+      String sub = (String) claims.get("sub");
+      Boolean emailVerified =
+          claims.get("email_verified") != null
+              ? Boolean.valueOf(claims.get("email_verified").toString())
+              : false;
+      Boolean isPrivateEmail =
+          claims.get("is_private_email") != null
+              ? Boolean.valueOf(claims.get("is_private_email").toString())
+              : false;
+
+      if (email == null || sub == null) {
+        log.error("Apple 사용자 정보 조회 실패: 이메일 또는 sub 정보 없음");
+        throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+      }
+
+      log.info("Apple 사용자 정보 조회 성공: {}", email);
+
+      return AppleUserInfo.builder()
+          .sub(sub)
+          .email(email)
+          .emailVerified(emailVerified)
+          .isPrivateEmail(isPrivateEmail)
+          .build();
+
+    } catch (CustomException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Apple Identity Token 파싱 중 오류 발생", e);
+      throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/client/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/teambiund/bander/auth_server/client/oauth/KakaoOAuthClient.java
@@ -1,0 +1,55 @@
+package com.teambiund.bander.auth_server.client.oauth;
+
+import com.teambiund.bander.auth_server.dto.response.KakaoUserInfo;
+import com.teambiund.bander.auth_server.exceptions.CustomException;
+import com.teambiund.bander.auth_server.exceptions.ErrorCode.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+  private final RestTemplate restTemplate;
+
+  @Value("${oauth.kakao.user-info-uri:https://kapi.kakao.com/v2/user/me}")
+  private String userInfoUri;
+
+  public KakaoUserInfo getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Bearer " + accessToken);
+    headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+    HttpEntity<String> request = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<KakaoUserInfo> response =
+          restTemplate.exchange(userInfoUri, HttpMethod.GET, request, KakaoUserInfo.class);
+
+      KakaoUserInfo userInfo = response.getBody();
+      if (userInfo == null || userInfo.getEmail() == null) {
+        log.error("카카오 사용자 정보 조회 실패: 이메일 정보 없음");
+        throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+      }
+
+      log.info("카카오 사용자 정보 조회 성공: {}", userInfo.getEmail());
+      return userInfo;
+
+    } catch (HttpClientErrorException e) {
+      log.error("카카오 API 호출 실패: {}", e.getMessage());
+      throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+    } catch (Exception e) {
+      log.error("카카오 사용자 정보 조회 중 오류 발생", e);
+      throw new CustomException(ErrorCode.SOCIAL_LOGIN_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/config/RestTemplateConfig.java
+++ b/src/main/java/com/teambiund/bander/auth_server/config/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.teambiund.bander.auth_server.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(5000);
+    factory.setReadTimeout(5000);
+    return new RestTemplate(factory);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/controller/SocialLoginController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/controller/SocialLoginController.java
@@ -1,0 +1,39 @@
+package com.teambiund.bander.auth_server.controller;
+
+import com.teambiund.bander.auth_server.dto.request.SocialLoginRequest;
+import com.teambiund.bander.auth_server.dto.response.LoginResponse;
+import com.teambiund.bander.auth_server.service.social.SocialLoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth/social")
+@RequiredArgsConstructor
+public class SocialLoginController {
+
+  private final SocialLoginService socialLoginService;
+
+  @PostMapping("/kakao")
+  public ResponseEntity<LoginResponse> kakaoLogin(@Valid @RequestBody SocialLoginRequest request) {
+    log.info("카카오 로그인 요청");
+    LoginResponse response =
+        socialLoginService.kakaoLogin(request.getAccessToken(), request.getDeviceId());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  @PostMapping("/apple")
+  public ResponseEntity<LoginResponse> appleLogin(@Valid @RequestBody SocialLoginRequest request) {
+    log.info("애플 로그인 요청");
+    LoginResponse response =
+        socialLoginService.appleLogin(request.getAccessToken(), request.getDeviceId());
+    return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/teambiund/bander/auth_server/dto/request/SocialLoginRequest.java
@@ -1,0 +1,21 @@
+package com.teambiund.bander.auth_server.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SocialLoginRequest {
+
+  @NotBlank(message = "액세스 토큰은 필수입니다")
+  private String accessToken;
+
+  private String deviceId;
+}

--- a/src/main/java/com/teambiund/bander/auth_server/dto/response/AppleUserInfo.java
+++ b/src/main/java/com/teambiund/bander/auth_server/dto/response/AppleUserInfo.java
@@ -1,0 +1,20 @@
+package com.teambiund.bander.auth_server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AppleUserInfo {
+
+  private String sub;
+  private String email;
+  private Boolean emailVerified;
+  private Boolean isPrivateEmail;
+}

--- a/src/main/java/com/teambiund/bander/auth_server/dto/response/KakaoUserInfo.java
+++ b/src/main/java/com/teambiund/bander/auth_server/dto/response/KakaoUserInfo.java
@@ -1,0 +1,42 @@
+package com.teambiund.bander.auth_server.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoUserInfo {
+
+  @JsonProperty("id")
+  private Long id;
+
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class KakaoAccount {
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("email_needs_agreement")
+    private Boolean emailNeedsAgreement;
+
+    @JsonProperty("is_email_valid")
+    private Boolean isEmailValid;
+
+    @JsonProperty("is_email_verified")
+    private Boolean isEmailVerified;
+  }
+
+  public String getEmail() {
+    if (kakaoAccount != null && kakaoAccount.getEmail() != null) {
+      return kakaoAccount.getEmail();
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/exceptions/ErrorCode/ErrorCode.java
+++ b/src/main/java/com/teambiund/bander/auth_server/exceptions/ErrorCode/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
   DECRYPTION_ERROR("DECRYPTION_ERROR", "Decryption error", HttpStatus.INTERNAL_SERVER_ERROR),
   INVALID_EMAIL("INVALID_EMAIL", "Invalid email", HttpStatus.BAD_REQUEST),
   INVALID_PASSWORD("INVALID_PASSWORD", "Invalid password", HttpStatus.BAD_REQUEST),
+  SOCIAL_LOGIN_FAILED("SOCIAL_LOGIN_FAILED", "Social login failed", HttpStatus.UNAUTHORIZED),
   ;
 
   private final String errCode;

--- a/src/main/java/com/teambiund/bander/auth_server/service/login/LoginService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/login/LoginService.java
@@ -1,9 +1,12 @@
 package com.teambiund.bander.auth_server.service.login;
 
 import com.teambiund.bander.auth_server.dto.response.LoginResponse;
+import com.teambiund.bander.auth_server.entity.Auth;
 
 public interface LoginService {
   LoginResponse login(String email, String password);
 
   LoginResponse refreshToken(String refreshToken, String deviceId);
+
+  LoginResponse generateLoginResponse(Auth auth, String deviceId);
 }

--- a/src/main/java/com/teambiund/bander/auth_server/service/social/SocialLoginService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/social/SocialLoginService.java
@@ -1,0 +1,66 @@
+package com.teambiund.bander.auth_server.service.social;
+
+import com.teambiund.bander.auth_server.client.oauth.AppleOAuthClient;
+import com.teambiund.bander.auth_server.client.oauth.KakaoOAuthClient;
+import com.teambiund.bander.auth_server.dto.response.AppleUserInfo;
+import com.teambiund.bander.auth_server.dto.response.KakaoUserInfo;
+import com.teambiund.bander.auth_server.dto.response.LoginResponse;
+import com.teambiund.bander.auth_server.entity.Auth;
+import com.teambiund.bander.auth_server.enums.Provider;
+import com.teambiund.bander.auth_server.exceptions.CustomException;
+import com.teambiund.bander.auth_server.exceptions.ErrorCode.ErrorCode;
+import com.teambiund.bander.auth_server.repository.AuthRepository;
+import com.teambiund.bander.auth_server.service.login.LoginService;
+import com.teambiund.bander.auth_server.service.signup.SignupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SocialLoginService {
+
+  private final KakaoOAuthClient kakaoOAuthClient;
+  private final AppleOAuthClient appleOAuthClient;
+  private final AuthRepository authRepository;
+  private final SignupService signupService;
+  private final LoginService loginService;
+
+  public LoginResponse kakaoLogin(String accessToken, String deviceId) {
+    KakaoUserInfo userInfo = kakaoOAuthClient.getUserInfo(accessToken);
+    String email = userInfo.getEmail();
+
+    return processLogin(email, Provider.KAKAO, deviceId);
+  }
+
+  public LoginResponse appleLogin(String identityToken, String deviceId) {
+    AppleUserInfo userInfo = appleOAuthClient.getUserInfo(identityToken);
+    String email = userInfo.getEmail();
+
+    return processLogin(email, Provider.APPLE, deviceId);
+  }
+
+  private LoginResponse processLogin(String email, Provider provider, String deviceId) {
+    Auth auth = authRepository.findByEmail(email).orElse(null);
+
+    if (auth == null) {
+      log.info("신규 사용자 회원가입 처리: email={}, provider={}", email, provider);
+      auth = signupService.signupFromOtherProvider(email, provider);
+    } else {
+      if (!auth.getProvider().equals(provider)) {
+        log.error(
+            "이미 다른 방식으로 가입된 이메일: email={}, existingProvider={}, requestProvider={}",
+            email,
+            auth.getProvider(),
+            provider);
+        throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
+      }
+      log.info("기존 사용자 로그인 처리: email={}, provider={}", email, provider);
+    }
+
+    return loginService.generateLoginResponse(auth, deviceId);
+  }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -71,5 +71,11 @@ security:
   aes:
     encryption-key: default-aes-encryption-key-change-in-production
 
+oauth:
+  kakao:
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+  apple:
+    issuer: https://appleid.apple.com
+
 
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,7 +7,9 @@ CREATE TABLE IF NOT EXISTS consents_name
     consent_name VARCHAR(255) NULL,
     version      VARCHAR(50)  NULL,
     consent_url  TEXT         NULL,
-    required     BOOLEAN      NOT NULL DEFAULT FALSE
+    required     BOOLEAN      NOT NULL DEFAULT FALSE,
+    KEY idx_consents_name_name (consent_name(191)),
+    KEY idx_consents_name_required (required)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;
@@ -24,7 +26,10 @@ CREATE TABLE IF NOT EXISTS auth
     status       ENUM ('ACTIVE','BLOCKED','DELETED','EXPIRED','UNCONFIRMED') NOT NULL,
     updated_at   DATETIME(6)                                                 NULL,
     version      INT                                                         NULL,
-    user_role    ENUM ('ADMIN','GUEST','PLACE_OWNER','USER')                 NOT NULL
+    user_role    ENUM ('ADMIN','GUEST','PLACE_OWNER','USER')                 NOT NULL,
+    KEY idx_auth_email (email(191)),
+    KEY idx_auth_status (status),
+    KEY idx_auth_created_at (created_at)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;
@@ -39,7 +44,8 @@ CREATE TABLE IF NOT EXISTS history
     updated_column      VARCHAR(255) NOT NULL,
     version             INT          NULL,
     user_id             VARCHAR(255) NOT NULL,
-    CONSTRAINT fk_history_user FOREIGN KEY (user_id) REFERENCES auth (id)
+    CONSTRAINT fk_history_user FOREIGN KEY (user_id) REFERENCES auth (id),
+    KEY idx_history_user_id (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;
@@ -66,7 +72,9 @@ CREATE TABLE IF NOT EXISTS suspend
     suspend_until DATE         NOT NULL,
     suspender     VARCHAR(255) NOT NULL,
     reason        VARCHAR(100) NOT NULL,
-    CONSTRAINT fk_suspend_user FOREIGN KEY (user_id) REFERENCES auth (id)
+    CONSTRAINT fk_suspend_user FOREIGN KEY (user_id) REFERENCES auth (id),
+    KEY idx_suspend_user_id (user_id),
+    KEY idx_suspend_until (suspend_until)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;
@@ -79,7 +87,10 @@ CREATE TABLE IF NOT EXISTS consent
     consent_id   VARCHAR(255) NOT NULL,
     consented_at DATETIME(6)  NOT NULL,
     CONSTRAINT fk_consent_user FOREIGN KEY (user_id) REFERENCES auth (id),
-    CONSTRAINT fk_consent_table FOREIGN KEY (consent_id) REFERENCES consents_name (id)
+    CONSTRAINT fk_consent_table FOREIGN KEY (consent_id) REFERENCES consents_name (id),
+    KEY idx_consent_user_id (user_id),
+    KEY idx_consent_consent_id (consent_id),
+    KEY idx_consent_user_consent (user_id, consent_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_general_ci;


### PR DESCRIPTION
## 목적

카카오와 애플 소셜 로그인 기능을 구현하여 사용자가 간편하게 로그인할 수 있도록 합니다.

## 구현 내용

### 1. OAuth 클라이언트

#### KakaoOAuthClient
- 카카오 사용자 정보 API 호출
- Access Token으로 사용자 이메일 조회
- 에러 처리 및 로깅

#### AppleOAuthClient
- Apple Identity Token JWT 파싱
- Base64 디코딩 및 Claim 추출
- 이메일 및 sub 정보 검증

### 2. 소셜 로그인 서비스

#### SocialLoginService
- 카카오/애플 통합 로그인 처리
- 신규 사용자 자동 회원가입
- 기존 사용자 로그인
- Provider 불일치 검증 (동일 이메일 다른 Provider 차단)

### 3. 컨트롤러 및 DTO

#### SocialLoginController
- POST /api/auth/social/kakao
- POST /api/auth/social/apple

#### DTO
- SocialLoginRequest: accessToken, deviceId
- KakaoUserInfo: 카카오 사용자 정보
- AppleUserInfo: 애플 사용자 정보

### 4. LoginService 개선

- generateLoginResponse 메서드 추가
  - 소셜 로그인에서 재사용 가능
  - deviceId 파라미터 지원
  - deviceId 미제공 시 자동 생성

### 5. 설정 및 인프라

- RestTemplateConfig: HTTP 클라이언트 Bean 설정
- application-dev.yaml: OAuth URI 설정
- ErrorCode 추가: SOCIAL_LOGIN_FAILED

## 주요 파일/모듈

```
src/main/java/com/teambiund/bander/auth_server/
├── client/oauth/
│   ├── KakaoOAuthClient.java (신규)
│   └── AppleOAuthClient.java (신규)
├── controller/
│   └── SocialLoginController.java (신규)
├── dto/
│   ├── request/SocialLoginRequest.java (신규)
│   └── response/
│       ├── KakaoUserInfo.java (신규)
│       └── AppleUserInfo.java (신규)
├── service/
│   ├── social/SocialLoginService.java (신규)
│   └── login/
│       ├── LoginService.java (수정)
│       └── LoginServiceImpl.java (수정)
├── config/RestTemplateConfig.java (신규)
└── exceptions/ErrorCode/ErrorCode.java (수정)

docs/SOCIAL_LOGIN_SETUP.md (신규)
src/main/resources/application-dev.yaml (수정)
```

## 로그인 흐름

1. 클라이언트가 카카오/애플 SDK를 통해 Access Token 또는 Identity Token 획득
2. Auth Server에 Token과 함께 로그인 요청
3. OAuth 클라이언트가 해당 플랫폼 API로 사용자 정보 조회
4. 이메일 기반으로 기존 사용자 확인
   - 신규 사용자: SignupService.signupFromOtherProvider 호출
   - 기존 사용자: Provider 일치 여부 확인
5. LoginService.generateLoginResponse로 JWT Token 발급

## API 명세

### 카카오 로그인

```bash
POST /api/auth/social/kakao
Content-Type: application/json

{
  "accessToken": "카카오 Access Token",
  "deviceId": "optional-device-id"
}
```

**Response:**
```json
{
  "accessToken": "JWT Access Token",
  "refreshToken": "JWT Refresh Token",
  "deviceId": "device-id"
}
```

### 애플 로그인

```bash
POST /api/auth/social/apple
Content-Type: application/json

{
  "accessToken": "애플 Identity Token (JWT)",
  "deviceId": "optional-device-id"
}
```

**Response:**
```json
{
  "accessToken": "JWT Access Token",
  "refreshToken": "JWT Refresh Token",
  "deviceId": "device-id"
}
```

## 수용 기준 검증

- [x] 카카오 OAuth 클라이언트 구현
- [x] 애플 OAuth 클라이언트 구현
- [x] 소셜 로그인 서비스 구현
- [x] 컨트롤러 엔드포인트 구현
- [x] Provider 불일치 검증
- [x] 신규 사용자 자동 회원가입
- [x] 기존 테스트 전체 통과
- [x] 빌드 성공
- [x] 설정 문서 작성

## 테스트

### 빌드 및 테스트 결과
```bash
./gradlew build
BUILD SUCCESSFUL

./gradlew test
BUILD SUCCESSFUL
전체 테스트 통과
```

### 수동 테스트 방법

#### 카카오 로그인 테스트
```bash
# 1. 카카오 SDK로 Access Token 획득 (클라이언트)
# 2. Auth Server 호출
curl -X POST http://localhost:8000/api/auth/social/kakao \
  -H 'Content-Type: application/json' \
  -d '{
    "accessToken": "{카카오 Access Token}",
    "deviceId": "test-device"
  }'
```

#### 애플 로그인 테스트
```bash
# 1. 애플 SDK로 Identity Token 획득 (클라이언트)
# 2. Auth Server 호출
curl -X POST http://localhost:8000/api/auth/social/apple \
  -H 'Content-Type: application/json' \
  -d '{
    "accessToken": "{애플 Identity Token}",
    "deviceId": "test-device"
  }'
```

## Provider 정책

### 중복 가입 방지
- 동일한 이메일로 다른 Provider 가입 불가
- 예: test@email.com으로 카카오 가입 후, 동일 이메일로 애플 가입 시도 시 EMAIL_ALREADY_EXISTS 에러

### 신규 사용자 처리
- Provider와 이메일만 저장
- 비밀번호 저장 안 함
- 자동으로 SYSTEM이 아닌 해당 Provider로 설정
- 프로필 생성 이벤트 자동 발행

## 브레이킹/마이그레이션

Breaking Change: 없음

새로운 기능 추가이므로 기존 기능에 영향 없음

## 설정 가이드

자세한 설정 방법은 docs/SOCIAL_LOGIN_SETUP.md 참조

### 카카오 설정 요약
1. Kakao Developers에서 애플리케이션 등록
2. 카카오 로그인 활성화
3. 이메일 동의항목 필수로 설정
4. REST API 키를 클라이언트에 제공

### 애플 설정 요약
1. Apple Developer에서 App ID 및 Services ID 등록
2. Sign in with Apple 활성화
3. Domains and Return URLs 설정
4. Key 생성 및 다운로드

## 코드 강점

### 1. 확장 가능한 구조
- OAuth 클라이언트를 독립적으로 분리
- 새로운 소셜 로그인 Provider 추가 용이
- SocialLoginService에서 통합 처리

### 2. 에러 처리
- 각 OAuth 클라이언트에서 명확한 에러 로깅
- 사용자 정보 누락 시 적절한 예외 처리
- Provider 불일치 시 명확한 에러 메시지

### 3. 재사용성
- LoginService.generateLoginResponse를 소셜 로그인에서도 재사용
- deviceId 자동 생성 로직 공통화

### 4. 문서화
- 설정 가이드 완비
- API 명세 및 예제 제공
- 트러블슈팅 가이드 포함

## 참조

- 카카오 로그인 API: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
- Sign in with Apple: https://developer.apple.com/documentation/sign_in_with_apple

## 체크리스트

- [x] 빌드 성공
- [x] 모든 테스트 통과
- [x] API 문서 작성
- [x] 설정 가이드 작성
- [x] 코드 리뷰 준비 완료