### PR TITLE
Refactor and simplify social login functionality

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/controller/SocialLoginController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/controller/SocialLoginController.java
@@ -24,16 +24,14 @@ public class SocialLoginController {
   @PostMapping("/kakao")
   public ResponseEntity<LoginResponse> kakaoLogin(@Valid @RequestBody SocialLoginRequest request) {
     log.info("카카오 로그인 요청");
-    LoginResponse response =
-        socialLoginService.kakaoLogin(request.getAccessToken(), request.getDeviceId());
+    LoginResponse response = socialLoginService.kakaoLogin(request.getAccessToken());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   @PostMapping("/apple")
   public ResponseEntity<LoginResponse> appleLogin(@Valid @RequestBody SocialLoginRequest request) {
     log.info("애플 로그인 요청");
-    LoginResponse response =
-        socialLoginService.appleLogin(request.getAccessToken(), request.getDeviceId());
+    LoginResponse response = socialLoginService.appleLogin(request.getAccessToken());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 }

--- a/src/main/java/com/teambiund/bander/auth_server/service/login/LoginService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/login/LoginService.java
@@ -8,5 +8,5 @@ public interface LoginService {
 
   LoginResponse refreshToken(String refreshToken, String deviceId);
 
-  LoginResponse generateLoginResponse(Auth auth, String deviceId);
+  LoginResponse generateLoginResponse(Auth auth);
 }

--- a/src/main/java/com/teambiund/bander/auth_server/service/login/LoginServiceImpl.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/login/LoginServiceImpl.java
@@ -117,8 +117,8 @@ public class LoginServiceImpl implements LoginService {
 
     }
 
-    @Override
-    public LoginResponse generateLoginResponse(Auth auth, String providedDeviceId) {
+  @Override
+  public LoginResponse generateLoginResponse(Auth auth) {
         if (!auth.getStatus().equals(Status.ACTIVE)) {
             switch (auth.getStatus()) {
                 case SLEEPING:
@@ -133,26 +133,7 @@ public class LoginServiceImpl implements LoginService {
                     break;
             }
         }
-
-        String deviceId = (providedDeviceId != null && !providedDeviceId.isEmpty())
-                ? providedDeviceId
-                : UUID.randomUUID().toString().substring(0, 4);
-
-        String accessToken = tokenUtil.generateAccessToken(auth.getId(), auth.getUserRole(), deviceId);
-        String refreshToken = tokenUtil.generateRefreshToken(auth.getId(), auth.getUserRole(), deviceId);
-
-        var response = new LoginResponse();
-        response.setAccessToken(accessToken);
-        response.setRefreshToken(refreshToken);
-        response.setDeviceId(deviceId);
-
-        LoginStatus loginStatus = LoginStatus.builder()
-                .lastLogin(LocalDateTime.now())
-                .build();
-
-        loginStatusRepository.save(loginStatus);
-
-        return response;
+    return generateResponse(auth);
     }
 
 

--- a/src/main/java/com/teambiund/bander/auth_server/service/social/SocialLoginService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/service/social/SocialLoginService.java
@@ -29,21 +29,21 @@ public class SocialLoginService {
   private final SignupService signupService;
   private final LoginService loginService;
 
-  public LoginResponse kakaoLogin(String accessToken, String deviceId) {
+  public LoginResponse kakaoLogin(String accessToken) {
     KakaoUserInfo userInfo = kakaoOAuthClient.getUserInfo(accessToken);
     String email = userInfo.getEmail();
 
-    return processLogin(email, Provider.KAKAO, deviceId);
+    return processLogin(email, Provider.KAKAO);
   }
 
-  public LoginResponse appleLogin(String identityToken, String deviceId) {
+  public LoginResponse appleLogin(String identityToken) {
     AppleUserInfo userInfo = appleOAuthClient.getUserInfo(identityToken);
     String email = userInfo.getEmail();
 
-    return processLogin(email, Provider.APPLE, deviceId);
+    return processLogin(email, Provider.APPLE);
   }
 
-  private LoginResponse processLogin(String email, Provider provider, String deviceId) {
+  private LoginResponse processLogin(String email, Provider provider) {
     Auth auth = authRepository.findByEmail(email).orElse(null);
 
     if (auth == null) {
@@ -61,6 +61,6 @@ public class SocialLoginService {
       log.info("기존 사용자 로그인 처리: email={}, provider={}", email, provider);
     }
 
-    return loginService.generateLoginResponse(auth, deviceId);
+    return loginService.generateLoginResponse(auth);
   }
 }


### PR DESCRIPTION
목적

- 소셜 로그인 기능에서 불필요한 `deviceId` 처리 로직을 제거하고, 로직을 간소화하기 위해 이 PR이 필요합니다.

변경 요약

- `deviceId` 파라미터 제거 및 관련 코드 삭제
- `generateLoginResponse` 메서드에서 `deviceId` 생성 및 저장 로직 제거
- 클라이언트의 소셜 로그인 대응 검토 필요 (로그인 응답에서 `deviceId` 필드 제거 가능성)

수용 기준 검증

- [ ] AC1: 클라이언트를 위한 소셜 로그인 요청이 정상적으로 처리된다.
- [ ] AC2: 제출된 로그인 응답 항목이 클라이언트 스펙 요구 사항과 일치한다.

브레이킹/마이그레이션

- `LoginResponse`에서 `deviceId` 필드 제거로 인해 클라이언트와 서버 간 호환성 검토 필요

테스트

- 단위 테스트:
  - 소셜 로그인 요청 처리
  - 로그인 응답 생성 로직 변경 확인
- 수동 검증 방법:
  1. 카카오 및 애플 소셜 로그인이 성공적으로 동작하는지 확인
  2. 로그인 응답 데이터가 변경 사항을 반영하는지 확인

참조

- 관련 Story/Epic/CR: 없음