### PR TITLE
[FEAT] user-consent-changed Kafka 이벤트 발행 구현

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/events/UserConsentChangedEvent.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/events/UserConsentChangedEvent.java
@@ -1,0 +1,17 @@
+package com.teambiund.bander.auth_server.auth.event.events;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserConsentChangedEvent {
+  private String userId;
+  private String consentId;
+  private Boolean consented;
+  private String changedAt;
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/UserConsentChangedEventPub.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/UserConsentChangedEventPub.java
@@ -1,0 +1,17 @@
+package com.teambiund.bander.auth_server.auth.event.publish;
+
+import com.teambiund.bander.auth_server.auth.event.events.UserConsentChangedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserConsentChangedEventPub {
+  private final EventPublisher eventPublisher;
+
+  private static final String TOPIC = "user-consent-changed";
+
+  public void publish(UserConsentChangedEvent event) {
+    eventPublisher.publish(TOPIC, event);
+  }
+}


### PR DESCRIPTION
## 목적

마케팅 동의 변경 시 Notification Service로 Kafka 이벤트를 발행하여, 광고성 알림 발송 필터링을 지원합니다.

## 변경 사항

### 신규 파일

| 파일 | 설명 |
|------|------|
| `UserConsentChangedEvent.java` | 동의 변경 이벤트 DTO |
| `UserConsentChangedEventPub.java` | Kafka 이벤트 Publisher |

### 수정 파일

| 파일 | 메서드 | 변경 내용 |
|------|--------|----------|
| `ConsentManagementServiceImpl.java` | `saveConsent()` | 회원가입 시 마케팅 동의 이벤트 발행 |
| `ConsentManagementServiceImpl.java` | `changeConsent()` | 동의 변경 시 마케팅 동의 이벤트 발행 |

## 토픽 및 스키마

**토픽**: `user-consent-changed`

**스키마**:
```json
{
  "userId": "string",
  "consentId": "MARKETING_CONSENT",
  "consented": true,
  "changedAt": "2025-01-15T10:30:00"
}
```

| 필드 | 타입 | 필수 | 설명 |
|------|------|------|------|
| userId | String | Y | auth.id 값 |
| consentId | String | Y | 동의 항목 ID (MARKETING_CONSENT) |
| consented | Boolean | Y | true=동의, false=철회 |
| changedAt | String (ISO8601) | Y | 변경 일시 |

## 발행 시점

- **saveConsent()**: 회원가입 시 마케팅 동의를 선택한 경우 `consented: true` 발행
- **changeConsent()**: 동의 변경 시
  - 동의 추가: `consented: true`
  - 동의 철회: `consented: false`

## 테스트

- [x] 빌드 성공
- [x] 전체 테스트 통과

## 관련 이슈

Closes #72