### PR TITLE
[FIX] 마케팅 동의 이벤트 항상 발행하도록 수정

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/auth/service/consent/impl/ConsentManagementServiceImpl.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/service/consent/impl/ConsentManagementServiceImpl.java
@@ -109,18 +109,19 @@ public class ConsentManagementServiceImpl implements ConsentManagementService {
   }
 
   private void publishMarketingConsentEvent(String userId, List<ConsentRequest> requests) {
-    requests.stream()
-        .filter(request -> MARKETING_CONSENT_ID.equals(request.getConsentId()))
-        .findFirst()
-        .ifPresent(
-            marketingConsent -> {
-              UserConsentChangedEvent event =
-                  new UserConsentChangedEvent(
-                      userId,
-                      MARKETING_CONSENT_ID,
-                      marketingConsent.isConsented(),
-                      LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
-              userConsentChangedEventPub.publish(event);
-            });
+    boolean consented =
+        requests.stream()
+            .filter(request -> MARKETING_CONSENT_ID.equals(request.getConsentId()))
+            .findFirst()
+            .map(ConsentRequest::isConsented)
+            .orElse(false);
+
+    UserConsentChangedEvent event =
+        new UserConsentChangedEvent(
+            userId,
+            MARKETING_CONSENT_ID,
+            consented,
+            LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+    userConsentChangedEventPub.publish(event);
   }
 }

--- a/src/test/java/com/teambiund/bander/auth_server/service/consent/ConsentManagementServiceImplTest.java
+++ b/src/test/java/com/teambiund/bander/auth_server/service/consent/ConsentManagementServiceImplTest.java
@@ -11,6 +11,7 @@ import com.teambiund.bander.auth_server.auth.entity.Auth;
 import com.teambiund.bander.auth_server.auth.entity.Consent;
 import com.teambiund.bander.auth_server.auth.entity.consentsname.ConsentsTable;
 import com.teambiund.bander.auth_server.auth.enums.Status;
+import com.teambiund.bander.auth_server.auth.event.publish.UserConsentChangedEventPub;
 import com.teambiund.bander.auth_server.auth.exception.CustomException;
 import com.teambiund.bander.auth_server.auth.exception.ErrorCode.AuthErrorCode;
 import com.teambiund.bander.auth_server.auth.repository.AuthRepository;
@@ -35,6 +36,8 @@ class ConsentManagementServiceImplTest {
   @Mock private AuthRepository authRepository;
 
   @Mock private KeyProvider keyProvider;
+
+  @Mock private UserConsentChangedEventPub userConsentChangedEventPub;
 
   @InjectMocks private ConsentManagementServiceImpl consentService;
 


### PR DESCRIPTION
## 목적

마케팅 동의 여부와 관계없이 항상 이벤트를 발행하도록 수정합니다.

## 문제

기존 로직은 `ifPresent()`를 사용하여 마케팅 동의 요청이 있을 때만 이벤트를 발행했습니다.
회원가입 시 마케팅 동의를 하지 않으면 이벤트가 발행되지 않는 문제가 있었습니다.

## 해결

`orElse(false)`를 사용하여 마케팅 동의 요청이 없어도 `consented: false`로 이벤트를 발행합니다.

## 변경 전

```java
requests.stream()
    .filter(request -> MARKETING_CONSENT_ID.equals(request.getConsentId()))
    .findFirst()
    .ifPresent(marketingConsent -> {
        // 이벤트 발행
    });
```

## 변경 후

```java
boolean consented = requests.stream()
    .filter(request -> MARKETING_CONSENT_ID.equals(request.getConsentId()))
    .findFirst()
    .map(ConsentRequest::isConsented)
    .orElse(false);

// 항상 이벤트 발행
userConsentChangedEventPub.publish(event);
```

## 테스트

- [x] 빌드 성공
- [x] 전체 테스트 통과

## 관련 이슈

Related to #72