### PR TITLE
[FEAT] SMS 인증 코드 발송 이벤트 구현

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/auth/controller/SmsConfirmController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/controller/SmsConfirmController.java
@@ -1,0 +1,96 @@
+package com.teambiund.bander.auth_server.auth.controller;
+
+import com.teambiund.bander.auth_server.auth.service.update.SmsConfirmService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "SMS 인증", description = "SMS 인증 관련 API")
+@RestController
+@RequestMapping("/api/v1/auth/sms")
+@RequiredArgsConstructor
+public class SmsConfirmController {
+
+  private final SmsConfirmService smsConfirmService;
+
+  @Operation(summary = "SMS 인증 코드 발급", description = "SMS 인증을 위한 인증 코드를 생성하고 발송합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "인증 코드 발급 성공"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "이미 발급된 인증 코드가 있음",
+            content = @Content(mediaType = "application/json"))
+      })
+  @PostMapping("/{userId}/{phoneNumber}")
+  public void generateCode(
+      @Parameter(description = "사용자 ID", required = true, example = "user-id-123")
+          @PathVariable(name = "userId")
+          String userId,
+      @Parameter(description = "전화번호", required = true, example = "01012345678")
+          @PathVariable(name = "phoneNumber")
+          String phoneNumber) {
+    smsConfirmService.generateCode(userId, phoneNumber);
+  }
+
+  @Operation(
+      summary = "SMS 인증 확인",
+      description = "인증 코드를 사용하여 SMS 인증을 완료합니다. 인증 완료 시 전화번호가 암호화되어 저장됩니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "인증 성공",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = Boolean.class),
+                    examples = @ExampleObject(value = "true"))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 인증 코드",
+            content = @Content(mediaType = "application/json"))
+      })
+  @GetMapping("/{userId}/{phoneNumber}")
+  public boolean confirmSms(
+      @Parameter(description = "인증 코드", required = true, example = "123456") @RequestParam
+          String code,
+      @Parameter(description = "사용자 ID", required = true, example = "user-id-123")
+          @PathVariable(name = "userId")
+          String userId,
+      @Parameter(description = "전화번호", required = true, example = "01012345678")
+          @PathVariable(name = "phoneNumber")
+          String phoneNumber) {
+    return smsConfirmService.confirmSms(userId, phoneNumber, code);
+  }
+
+  @Operation(summary = "SMS 인증 코드 재발신", description = "SMS 인증 코드를 재발신합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "재발신 성공",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = Boolean.class),
+                    examples = @ExampleObject(value = "true")))
+      })
+  @PutMapping("/{userId}/{phoneNumber}")
+  public boolean resendSms(
+      @Parameter(description = "사용자 ID", required = true, example = "user-id-123")
+          @PathVariable(name = "userId")
+          String userId,
+      @Parameter(description = "전화번호", required = true, example = "01012345678")
+          @PathVariable(name = "phoneNumber")
+          String phoneNumber) {
+    return smsConfirmService.resendSms(userId, phoneNumber);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/events/PhoneNumberVerifiedEvent.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/events/PhoneNumberVerifiedEvent.java
@@ -1,0 +1,13 @@
+package com.teambiund.bander.auth_server.auth.event.events;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhoneNumberVerifiedEvent {
+  private String userId;
+  private String phoneNumber;
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/events/SmsConfirmRequest.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/events/SmsConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.teambiund.bander.auth_server.auth.event.events;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SmsConfirmRequest {
+  private String phoneNumber;
+  private String code;
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/PhoneNumberVerifiedEventPub.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/PhoneNumberVerifiedEventPub.java
@@ -1,0 +1,17 @@
+package com.teambiund.bander.auth_server.auth.event.publish;
+
+import com.teambiund.bander.auth_server.auth.event.events.PhoneNumberVerifiedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhoneNumberVerifiedEventPub {
+  private final EventPublisher eventPublisher;
+
+  private static final String TOPIC = "phone-number-verified";
+
+  public void publish(PhoneNumberVerifiedEvent event) {
+    eventPublisher.publish(TOPIC, event);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/SmsConfirmRequestEventPub.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/event/publish/SmsConfirmRequestEventPub.java
@@ -1,0 +1,17 @@
+package com.teambiund.bander.auth_server.auth.event.publish;
+
+import com.teambiund.bander.auth_server.auth.event.events.SmsConfirmRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmsConfirmRequestEventPub {
+  private final EventPublisher eventPublisher;
+
+  private static final String TOPIC = "sms-confirm-request";
+
+  public void publish(SmsConfirmRequest req) {
+    eventPublisher.publish(TOPIC, req);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/service/update/SmsConfirmService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/service/update/SmsConfirmService.java
@@ -1,0 +1,39 @@
+package com.teambiund.bander.auth_server.auth.service.update;
+
+public interface SmsConfirmService {
+
+  /**
+   * SMS 인증 코드 발급 및 이벤트 발행
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   */
+  void generateCode(String userId, String phoneNumber);
+
+  /**
+   * SMS 인증 코드 확인
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @param code 인증 코드
+   * @return 인증 성공 여부
+   */
+  boolean confirmSms(String userId, String phoneNumber, String code);
+
+  /**
+   * SMS 인증 코드 재발신
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @return 재발신 성공 여부
+   */
+  boolean resendSms(String userId, String phoneNumber);
+
+  /**
+   * 인증 완료 후 전화번호 저장
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   */
+  void savePhoneNumber(String userId, String phoneNumber);
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/service/update/impl/SmsConfirmServiceImpl.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/service/update/impl/SmsConfirmServiceImpl.java
@@ -1,0 +1,67 @@
+package com.teambiund.bander.auth_server.auth.service.update.impl;
+
+import com.teambiund.bander.auth_server.auth.event.events.PhoneNumberUpdateRequest;
+import com.teambiund.bander.auth_server.auth.event.events.PhoneNumberVerifiedEvent;
+import com.teambiund.bander.auth_server.auth.event.events.SmsConfirmRequest;
+import com.teambiund.bander.auth_server.auth.event.publish.PhoneNumberVerifiedEventPub;
+import com.teambiund.bander.auth_server.auth.event.publish.SmsConfirmRequestEventPub;
+import com.teambiund.bander.auth_server.auth.service.update.PhoneNumberUpdateService;
+import com.teambiund.bander.auth_server.auth.service.update.SmsConfirmService;
+import com.teambiund.bander.auth_server.auth.util.generator.generate_code.SmsCodeGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsConfirmServiceImpl implements SmsConfirmService {
+
+  private final SmsCodeGenerator smsCodeGenerator;
+  private final SmsConfirmRequestEventPub smsConfirmRequestEventPub;
+  private final PhoneNumberVerifiedEventPub phoneNumberVerifiedEventPub;
+  private final PhoneNumberUpdateService phoneNumberUpdateService;
+
+  @Override
+  public void generateCode(String userId, String phoneNumber) {
+    String code = smsCodeGenerator.generateCode(userId, phoneNumber);
+    smsConfirmRequestEventPub.publish(new SmsConfirmRequest(phoneNumber, code));
+    log.info("SMS 인증 코드 이벤트 발행 완료 - userId: {}", userId);
+  }
+
+  @Override
+  public boolean confirmSms(String userId, String phoneNumber, String code) {
+    boolean isValid = smsCodeGenerator.checkCode(userId, phoneNumber, code);
+
+    if (isValid) {
+      // 인증 성공 시 전화번호 암호화 저장
+      savePhoneNumber(userId, phoneNumber);
+    }
+
+    return isValid;
+  }
+
+  @Override
+  public boolean resendSms(String userId, String phoneNumber) {
+    if (smsCodeGenerator.canResend(userId, phoneNumber)) {
+      generateCode(userId, phoneNumber);
+      return true;
+    }
+
+    // 기존 코드가 있으면 삭제 후 재발신
+    smsCodeGenerator.deleteCode(userId, phoneNumber);
+    generateCode(userId, phoneNumber);
+    return true;
+  }
+
+  @Override
+  public void savePhoneNumber(String userId, String phoneNumber) {
+    PhoneNumberUpdateRequest req = new PhoneNumberUpdateRequest(userId, phoneNumber);
+    phoneNumberUpdateService.updatePhoneNumber(req);
+    log.info("전화번호 저장 완료 - userId: {}", userId);
+
+    // Notification Service에 전화번호 인증 완료 이벤트 발행
+    phoneNumberVerifiedEventPub.publish(new PhoneNumberVerifiedEvent(userId, phoneNumber));
+    log.info("전화번호 인증 완료 이벤트 발행 - userId: {}", userId);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/util/generator/generate_code/SmsCodeGenerator.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/util/generator/generate_code/SmsCodeGenerator.java
@@ -1,0 +1,135 @@
+package com.teambiund.bander.auth_server.auth.util.generator.generate_code;
+
+import com.teambiund.bander.auth_server.auth.exception.CustomException;
+import com.teambiund.bander.auth_server.auth.exception.ErrorCode.AuthErrorCode;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class SmsCodeGenerator {
+  private static final int DEFAULT_EXPIRE_SECONDS = 300; // 5분
+  private static final String CODE_PREFIX = "sms:";
+
+  private final StringRedisTemplate redisTemplate;
+
+  @Value("${sms.code.length:6}")
+  private int codeLength;
+
+  @Value("${sms.code.expire.time:300}")
+  private int codeExpireTime;
+
+  public SmsCodeGenerator(StringRedisTemplate redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  /**
+   * SMS 인증 코드 생성 및 Redis 저장
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @return 생성된 인증 코드
+   */
+  public String generateCode(String userId, String phoneNumber) {
+    String key = buildKey(userId, phoneNumber);
+
+    // 이미 발급된 코드가 있는지 확인
+    if (redisTemplate.opsForValue().get(key) != null) {
+      throw new CustomException(AuthErrorCode.ALREADY_GENERATE_CODE);
+    }
+
+    // 6자리 인증 코드 생성
+    StringBuilder code = new StringBuilder();
+    while (code.length() < codeLength) {
+      code.append((int) (Math.random() * 10));
+    }
+
+    String result = code.toString();
+
+    // Redis에 저장 (TTL 적용)
+    int ttl = codeExpireTime > 0 ? codeExpireTime : DEFAULT_EXPIRE_SECONDS;
+    Duration expireSeconds = Duration.ofSeconds(ttl);
+    redisTemplate.opsForValue().set(key, result, expireSeconds);
+
+    log.info("SMS 인증 코드 Redis 저장 완료 - key: {}, userId: {}", key, userId);
+    return result;
+  }
+
+  /**
+   * SMS 인증 코드 검증
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @param code 인증 코드
+   * @return 인증 성공 여부
+   */
+  public boolean checkCode(String userId, String phoneNumber, String code) {
+    String key = buildKey(userId, phoneNumber);
+    String storedCode = redisTemplate.opsForValue().get(key);
+
+    if (storedCode == null) {
+      log.info("SMS 인증 코드가 존재하지 않음 - userId: {}", userId);
+      return false;
+    }
+
+    if (!storedCode.equals(code)) {
+      log.info("SMS 인증 코드 불일치 - userId: {}", userId);
+      return false;
+    }
+
+    // 인증 성공 시 코드를 "confirmed"로 변경
+    redisTemplate.opsForValue().set(key, "confirmed", Duration.ofMinutes(10));
+    log.info("SMS 인증 성공 - userId: {}", userId);
+    return true;
+  }
+
+  /**
+   * 인증 완료 여부 확인 및 키 삭제
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @return 인증 완료 여부
+   */
+  public boolean isConfirmed(String userId, String phoneNumber) {
+    String key = buildKey(userId, phoneNumber);
+    String storedValue = redisTemplate.opsForValue().get(key);
+
+    if (storedValue == null || !storedValue.equals("confirmed")) {
+      return false;
+    }
+
+    // 확인 후 키 삭제
+    redisTemplate.delete(key);
+    return true;
+  }
+
+  /**
+   * 재발신 가능 여부 확인
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   * @return 재발신 가능 여부
+   */
+  public boolean canResend(String userId, String phoneNumber) {
+    String key = buildKey(userId, phoneNumber);
+    return redisTemplate.opsForValue().get(key) == null;
+  }
+
+  /**
+   * 기존 코드 삭제 (재발신을 위해)
+   *
+   * @param userId 사용자 ID
+   * @param phoneNumber 전화번호
+   */
+  public void deleteCode(String userId, String phoneNumber) {
+    String key = buildKey(userId, phoneNumber);
+    redisTemplate.delete(key);
+  }
+
+  private String buildKey(String userId, String phoneNumber) {
+    return CODE_PREFIX + userId + ":" + phoneNumber;
+  }
+}


### PR DESCRIPTION
## 목적

SMS 인증을 위한 Kafka 이벤트 발행 기능을 구현합니다.
Notification Service에서 SMS 발송을 처리할 수 있도록 이벤트를 제공합니다.

## Kafka 토픽

### 1. `sms-confirm-request`
**발행 시점**: SMS 인증 코드 발급 시

```json
{
  "phoneNumber": "01012345678",
  "code": "123456"
}
```

### 2. `phone-number-verified`
**발행 시점**: SMS 인증 완료 시

```json
{
  "userId": "user-id-123",
  "phoneNumber": "01012345678"
}
```

## API 엔드포인트

| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/v1/auth/sms/{userId}/{phoneNumber}` | 인증 코드 발급 |
| GET | `/api/v1/auth/sms/{userId}/{phoneNumber}?code=123456` | 인증 확인 |
| PUT | `/api/v1/auth/sms/{userId}/{phoneNumber}` | 재발신 |

## 인증 플로우

```
1. 클라이언트 → POST /api/v1/auth/sms/{userId}/{phoneNumber}
2. Auth Server → 인증 코드 생성 (6자리)
3. Auth Server → Redis 저장 (key: sms:{userId}:{phoneNumber}, TTL: 5분)
4. Auth Server → sms-confirm-request 이벤트 발행
5. Notification Service → SMS 발송
6. 사용자 → SMS 수신
7. 클라이언트 → GET /api/v1/auth/sms/{userId}/{phoneNumber}?code=123456
8. Auth Server → Redis 검증
9. Auth Server → 성공 시 phoneNumber 암호화 → DB 저장
10. Auth Server → phone-number-verified 이벤트 발행
```

## 신규 파일

| 파일 | 설명 |
|------|------|
| `SmsConfirmRequest.java` | SMS 인증 코드 발송 이벤트 DTO |
| `PhoneNumberVerifiedEvent.java` | 전화번호 인증 완료 이벤트 DTO |
| `SmsConfirmRequestEventPub.java` | sms-confirm-request Publisher |
| `PhoneNumberVerifiedEventPub.java` | phone-number-verified Publisher |
| `SmsCodeGenerator.java` | 인증 코드 생성 및 Redis 저장 |
| `SmsConfirmService.java` | 서비스 인터페이스 |
| `SmsConfirmServiceImpl.java` | 서비스 구현체 |
| `SmsConfirmController.java` | API 컨트롤러 |

## Redis 키 구조

- **키**: `sms:{userId}:{phoneNumber}`
- **값**: 인증 코드 (6자리) 또는 "confirmed"
- **TTL**: 5분 (인증 코드) / 10분 (confirmed 상태)

## 테스트

- [x] 빌드 성공
- [x] 전체 테스트 통과

## 관련 이슈

Closes #75