### PR TITLE
[FEAT] X-App-Type 헤더 기반 로그인 분리

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/auth/controller/LoginController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/controller/LoginController.java
@@ -3,8 +3,10 @@ package com.teambiund.bander.auth_server.auth.controller;
 import com.teambiund.bander.auth_server.auth.dto.request.LoginRequest;
 import com.teambiund.bander.auth_server.auth.dto.request.TokenRefreshRequest;
 import com.teambiund.bander.auth_server.auth.dto.response.LoginResponse;
+import com.teambiund.bander.auth_server.auth.enums.AppType;
 import com.teambiund.bander.auth_server.auth.service.login.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,9 +14,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -79,8 +83,18 @@ public class LoginController {
                       """)))
           @Valid
           @RequestBody
-          LoginRequest loginRequest) {
-    return loginService.login(loginRequest.getEmail(), loginRequest.getPassword());
+          LoginRequest loginRequest,
+      @Parameter(
+              description = "앱 타입 (GENERAL: 일반 앱, PLACE_MANAGER: 공간관리자 앱). 미지정 시 GENERAL로 처리",
+              example = "GENERAL")
+          @RequestHeader(value = "X-App-Type", required = false)
+          String appTypeHeader) {
+    AppType appType =
+        Optional.ofNullable(appTypeHeader)
+            .filter(s -> !s.isBlank())
+            .map(AppType::valueOf)
+            .orElse(AppType.GENERAL);
+    return loginService.login(loginRequest.getEmail(), loginRequest.getPassword(), appType);
   }
 
   @Operation(summary = "토큰 갱신", description = "Refresh 토큰을 사용하여 새로운 Access 토큰과 Refresh 토큰을 발급받습니다.")
@@ -133,7 +147,17 @@ public class LoginController {
                       """)))
           @Valid
           @RequestBody
-          TokenRefreshRequest request) {
-    return loginService.refreshToken(request.getRefreshToken(), request.getDeviceId());
+          TokenRefreshRequest request,
+      @Parameter(
+              description = "앱 타입 (GENERAL: 일반 앱, PLACE_MANAGER: 공간관리자 앱). 미지정 시 GENERAL로 처리",
+              example = "GENERAL")
+          @RequestHeader(value = "X-App-Type", required = false)
+          String appTypeHeader) {
+    AppType appType =
+        Optional.ofNullable(appTypeHeader)
+            .filter(s -> !s.isBlank())
+            .map(AppType::valueOf)
+            .orElse(AppType.GENERAL);
+    return loginService.refreshToken(request.getRefreshToken(), request.getDeviceId(), appType);
   }
 }

--- a/src/main/java/com/teambiund/bander/auth_server/auth/enums/AppType.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/enums/AppType.java
@@ -1,0 +1,6 @@
+package com.teambiund.bander.auth_server.auth.enums;
+
+public enum AppType {
+  GENERAL,       // 일반 앱 (USER, GUEST, PLACE_OWNER 모두 로그인 가능)
+  PLACE_MANAGER  // 공간관리자 앱 (PLACE_OWNER만 로그인 가능)
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/exception/ErrorCode/AuthErrorCode.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/exception/ErrorCode/AuthErrorCode.java
@@ -52,6 +52,10 @@ public enum AuthErrorCode implements ErrorCodeType {
   INVALID_EMAIL("INVALID_EMAIL", "Invalid email", HttpStatus.BAD_REQUEST),
   INVALID_PASSWORD("INVALID_PASSWORD", "Invalid password", HttpStatus.BAD_REQUEST),
   SOCIAL_LOGIN_FAILED("SOCIAL_LOGIN_FAILED", "Social login failed", HttpStatus.UNAUTHORIZED),
+  UNAUTHORIZED_APP_ACCESS(
+      "UNAUTHORIZED_APP_ACCESS",
+      "This account is not authorized to access this app",
+      HttpStatus.FORBIDDEN),
   ;
 
   private final String errCode;

--- a/src/main/java/com/teambiund/bander/auth_server/auth/service/login/LoginService.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/service/login/LoginService.java
@@ -2,11 +2,12 @@ package com.teambiund.bander.auth_server.auth.service.login;
 
 import com.teambiund.bander.auth_server.auth.dto.response.LoginResponse;
 import com.teambiund.bander.auth_server.auth.entity.Auth;
+import com.teambiund.bander.auth_server.auth.enums.AppType;
 
 public interface LoginService {
-  LoginResponse login(String email, String password);
+  LoginResponse login(String email, String password, AppType appType);
 
-  LoginResponse refreshToken(String refreshToken, String deviceId);
+  LoginResponse refreshToken(String refreshToken, String deviceId, AppType appType);
 
   LoginResponse generateLoginResponse(Auth auth);
 }

--- a/src/test/java/com/teambiund/bander/auth_server/integration/EmailEncryptionAtRestIntegrationTest.java
+++ b/src/test/java/com/teambiund/bander/auth_server/integration/EmailEncryptionAtRestIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.teambiund.bander.auth_server.AuthServerApplication;
 import com.teambiund.bander.auth_server.auth.dto.response.LoginResponse;
 import com.teambiund.bander.auth_server.auth.entity.Auth;
+import com.teambiund.bander.auth_server.auth.enums.AppType;
 import com.teambiund.bander.auth_server.auth.enums.Provider;
 import com.teambiund.bander.auth_server.auth.enums.Role;
 import com.teambiund.bander.auth_server.auth.enums.Status;
@@ -146,7 +147,7 @@ public class EmailEncryptionAtRestIntegrationTest {
         .thenReturn("mock-refresh-token");
 
     // when: 평문 이메일과 비밀번호로 로그인 시도
-    LoginResponse response = loginService.login(plainEmail, plainPassword);
+    LoginResponse response = loginService.login(plainEmail, plainPassword, AppType.GENERAL);
 
     // then: 로그인 성공
     assertThat(response).isNotNull();
@@ -187,7 +188,7 @@ public class EmailEncryptionAtRestIntegrationTest {
 
     // when: 로그인 수행 시간 측정
     long startTime = System.currentTimeMillis();
-    LoginResponse response = loginService.login(targetPlainEmail, plainPassword);
+    LoginResponse response = loginService.login(targetPlainEmail, plainPassword, AppType.GENERAL);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
 
@@ -232,7 +233,7 @@ public class EmailEncryptionAtRestIntegrationTest {
 
     // when: 로그인 수행 시간 측정
     long startTime = System.currentTimeMillis();
-    LoginResponse response = loginService.login(targetPlainEmail, plainPassword);
+    LoginResponse response = loginService.login(targetPlainEmail, plainPassword, AppType.GENERAL);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
 

--- a/src/test/java/com/teambiund/bander/auth_server/service/login/LoginServiceImplTest.java
+++ b/src/test/java/com/teambiund/bander/auth_server/service/login/LoginServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import com.teambiund.bander.auth_server.auth.dto.response.LoginResponse;
 import com.teambiund.bander.auth_server.auth.entity.Auth;
+import com.teambiund.bander.auth_server.auth.enums.AppType;
 import com.teambiund.bander.auth_server.auth.enums.Provider;
 import com.teambiund.bander.auth_server.auth.enums.Role;
 import com.teambiund.bander.auth_server.auth.enums.Status;
@@ -91,7 +92,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when
-      LoginResponse response = loginService.login(email, password);
+      LoginResponse response = loginService.login(email, password, AppType.GENERAL);
 
       // then
       assertThat(response).isNotNull();
@@ -136,7 +137,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when
-      LoginResponse response = loginService.login(email, password);
+      LoginResponse response = loginService.login(email, password, AppType.GENERAL);
 
       // then
       assertThat(response).isNotNull();
@@ -157,7 +158,7 @@ class LoginServiceImplTest {
       when(authRepository.findByEmailWithLoginStatus(email)).thenReturn(Optional.empty());
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.USER_NOT_FOUND);
 
@@ -187,7 +188,7 @@ class LoginServiceImplTest {
       when(passwordEncoder.matches(password, hashedPassword)).thenReturn(false);
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.PASSWORD_MISMATCH);
 
@@ -222,7 +223,7 @@ class LoginServiceImplTest {
           .thenAnswer(invocation -> invocation.getArgument(0));
 
       // when
-      loginService.login(email, password);
+      loginService.login(email, password, AppType.GENERAL);
 
       // then
       ArgumentCaptor<Auth> authCaptor = ArgumentCaptor.forClass(Auth.class);
@@ -259,7 +260,7 @@ class LoginServiceImplTest {
       when(passwordEncoder.matches(password, "hashedPassword")).thenReturn(true);
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.USER_IS_SLEEPING);
 
@@ -288,7 +289,7 @@ class LoginServiceImplTest {
       when(passwordEncoder.matches(password, "hashedPassword")).thenReturn(true);
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class);
     }
 
@@ -314,7 +315,7 @@ class LoginServiceImplTest {
       when(passwordEncoder.matches(password, "hashedPassword")).thenReturn(true);
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class);
     }
 
@@ -340,7 +341,7 @@ class LoginServiceImplTest {
       when(passwordEncoder.matches(password, "hashedPassword")).thenReturn(true);
 
       // when & then
-      assertThatThrownBy(() -> loginService.login(email, password))
+      assertThatThrownBy(() -> loginService.login(email, password, AppType.GENERAL))
           .isInstanceOf(CustomException.class);
     }
   }
@@ -376,7 +377,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when
-      LoginResponse response = loginService.refreshToken(refreshToken, deviceId);
+      LoginResponse response = loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL);
 
       // then
       assertThat(response).isNotNull();
@@ -400,7 +401,7 @@ class LoginServiceImplTest {
       when(tokenUtil.isValid(refreshToken)).thenReturn(false);
 
       // when & then
-      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId))
+      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.EXPIRED_TOKEN);
 
@@ -420,7 +421,7 @@ class LoginServiceImplTest {
       when(tokenUtil.extractDeviceId(refreshToken)).thenReturn(deviceId);
 
       // when & then
-      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId))
+      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.INVALID_TOKEN);
 
@@ -440,7 +441,7 @@ class LoginServiceImplTest {
       when(tokenUtil.extractDeviceId(refreshToken)).thenReturn(tokenDeviceId);
 
       // when & then
-      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId))
+      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.INVALID_DEVICE_ID);
 
@@ -461,7 +462,7 @@ class LoginServiceImplTest {
       when(authRepository.findByIdWithLoginStatus(userId)).thenReturn(Optional.empty());
 
       // when & then
-      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId))
+      assertThatThrownBy(() -> loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL))
           .isInstanceOf(CustomException.class)
           .hasFieldOrPropertyWithValue("errorcode", AuthErrorCode.USER_NOT_FOUND);
 
@@ -496,7 +497,7 @@ class LoginServiceImplTest {
           .thenAnswer(invocation -> invocation.getArgument(0));
 
       // when
-      loginService.refreshToken(refreshToken, deviceId);
+      loginService.refreshToken(refreshToken, deviceId, AppType.GENERAL);
 
       // then
       ArgumentCaptor<Auth> authCaptor = ArgumentCaptor.forClass(Auth.class);
@@ -537,7 +538,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when - 로그인
-      LoginResponse loginResponse = loginService.login(email, password);
+      LoginResponse loginResponse = loginService.login(email, password, AppType.GENERAL);
 
       // then
       assertThat(loginResponse.getAccessToken()).isEqualTo("access-token");
@@ -555,7 +556,7 @@ class LoginServiceImplTest {
           .thenReturn("new-refresh-token");
 
       // when - 리프레시
-      LoginResponse refreshResponse = loginService.refreshToken("refresh-token", deviceId);
+      LoginResponse refreshResponse = loginService.refreshToken("refresh-token", deviceId, AppType.GENERAL);
 
       // then
       assertThat(refreshResponse.getAccessToken()).isEqualTo("new-access-token");
@@ -589,7 +590,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(adminAuth);
 
       // when
-      LoginResponse response = loginService.login(email, password);
+      LoginResponse response = loginService.login(email, password, AppType.GENERAL);
 
       // then
       assertThat(response).isNotNull();
@@ -630,7 +631,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when
-      loginService.login(email, password);
+      loginService.login(email, password, AppType.GENERAL);
 
       // then - passwordEncoder.matches가 호출되었는지 확인 (평문 비교가 아님)
       verify(passwordEncoder).matches(password, hashedPassword);
@@ -663,7 +664,7 @@ class LoginServiceImplTest {
       when(authRepository.save(any(Auth.class))).thenReturn(auth);
 
       // when
-      loginService.login(email, password);
+      loginService.login(email, password, AppType.GENERAL);
 
       // then
       verify(emailCipher).encrypt(email);


### PR DESCRIPTION
## Summary
- 일반 앱과 공간관리자 앱의 로그인 분리 구현
- X-App-Type 헤더로 앱 타입 구분 (GENERAL, PLACE_MANAGER)
- 헤더 미지정 시 기본값 GENERAL 적용 (하위 호환성 유지)

## Changes
- `AppType` enum 추가
- `LoginService`/`LoginServiceImpl`에 앱 타입 검증 로직 추가
- `LoginController`에서 X-App-Type 헤더 처리
- `UNAUTHORIZED_APP_ACCESS` 에러 코드 추가

## Test plan
- [x] 기존 로그인 테스트 통과
- [ ] PLACE_MANAGER 앱에서 USER 로그인 시 403 반환 확인
- [ ] PLACE_OWNER는 양쪽 앱 모두 로그인 가능 확인

Closes #82
Related: #80, #79