### PR TITLE
[FEAT] 내부망 전용 역할 변경 API

### DIFF
--- a/src/main/java/com/teambiund/bander/auth_server/auth/controller/RoleController.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/controller/RoleController.java
@@ -1,0 +1,62 @@
+package com.teambiund.bander.auth_server.auth.controller;
+
+import com.teambiund.bander.auth_server.auth.dto.request.RoleChangeRequest;
+import com.teambiund.bander.auth_server.auth.service.auth_service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "역할 관리 (내부망)", description = "내부망 전용 사용자 역할 변경 API")
+@RestController
+@RequestMapping("/api/internal/v1/auth/role")
+@RequiredArgsConstructor
+public class RoleController {
+
+  private final AuthService authService;
+
+  @Operation(
+      summary = "사용자 역할 변경",
+      description = "이메일로 사용자를 찾아 역할을 변경합니다. (내부망 전용, 권한 검증 없음)")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "역할 변경 성공"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(mediaType = "application/json"))
+      })
+  @PutMapping("")
+  public ResponseEntity<Boolean> changeRole(
+      @io.swagger.v3.oas.annotations.parameters.RequestBody(
+              description = "역할 변경 요청 정보",
+              required = true,
+              content =
+                  @Content(
+                      schema = @Schema(implementation = RoleChangeRequest.class),
+                      examples =
+                          @ExampleObject(
+                              value =
+                                  """
+                      {
+                        "email": "user@example.com",
+                        "role": "PLACE_OWNER"
+                      }
+                      """)))
+          @Valid
+          @RequestBody
+          RoleChangeRequest request) {
+    authService.changeRole(request.getEmail(), request.getRole());
+    return ResponseEntity.ok(true);
+  }
+}

--- a/src/main/java/com/teambiund/bander/auth_server/auth/dto/request/RoleChangeRequest.java
+++ b/src/main/java/com/teambiund/bander/auth_server/auth/dto/request/RoleChangeRequest.java
@@ -1,0 +1,22 @@
+package com.teambiund.bander.auth_server.auth.dto.request;
+
+import com.teambiund.bander.auth_server.auth.enums.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoleChangeRequest {
+  @NotBlank(message = "이메일은 필수입니다")
+  @Email(message = "올바른 이메일 형식이 아닙니다")
+  private String email;
+
+  @NotNull(message = "변경할 역할은 필수입니다")
+  private Role role;
+}


### PR DESCRIPTION
## Summary
- 내부망에서 사용자 역할을 변경할 수 있는 API 추가
- 이메일로 사용자를 찾아 역할 변경 가능
- 권한 검증 없이 단순 API 호출로 변경

## Changes
- `RoleChangeRequest` DTO 추가 (email, role)
- `AuthService`에 `changeRole` 메서드 추가
- `RoleController` 추가 (`/api/internal/v1/auth/role`)

## API Usage
```http
PUT /api/internal/v1/auth/role
Content-Type: application/json

{
  "email": "user@example.com",
  "role": "PLACE_OWNER"
}
```

## Test plan
- [ ] 존재하는 사용자 역할 변경 성공 확인
- [ ] 존재하지 않는 사용자 시 404 반환 확인
- [ ] 게이트웨이에서 내부망 접근 제한 설정 필요

Closes #83
Related: #81, #79